### PR TITLE
alembic: add option to leave logging configuration untouched

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -13,6 +13,10 @@ script_location = alembic
 # the 'revision' command, regardless of autogenerate
 # revision_environment = false
 
+# set to 'false' to leave the logging config untouched, when calling
+# alembic from Python API
+#configure_logging = true
+
 sqlalchemy.url = postgresql://asterisk:proformatique@localhost/asterisk
 
 

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,5 +1,5 @@
 
-# Copyright 2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
@@ -14,7 +14,8 @@ config = context.config
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
-fileConfig(config.config_file_name)
+if config.get_main_option('configure_logging', 'true') == 'true':
+    fileConfig(config.config_file_name)
 
 # other values from the config, defined by the needs of env.py,
 # can be acquired:


### PR DESCRIPTION
reason: in xivo-tools/compare-db, we access alembic from Python API
instead of CLI, and we dont want alembic to reset the logging
configuration