### PR TITLE
endpoint_sip: remove the context_id field

### DIFF
--- a/alembic/versions/ee773d263d87_remove_endpoint_sip_context.py
+++ b/alembic/versions/ee773d263d87_remove_endpoint_sip_context.py
@@ -1,0 +1,25 @@
+"""remove-endpoint-sip-context
+
+Revision ID: ee773d263d87
+Revises: 42b0914ed3e6
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'ee773d263d87'
+down_revision = '42b0914ed3e6'
+
+
+def upgrade():
+    op.drop_column('endpoint_sip', 'context_id')
+
+
+def downgrade():
+    op.add_column(
+        'endpoint_sip',
+        sa.Column('context_id', sa.Integer, sa.ForeignKey('context.id')),
+    )


### PR DESCRIPTION
when the context of an endpoint is needed the context of the line or trunk can
be used.

this avoids duplicating the context and adding logic to keep the 2 fields
consistent across tables.