### PR TITLE
sip-to-pjsip: preserve old names

### DIFF
--- a/alembic/versions/ea74eca400ce_sip_to_pjsip_endpoint.py
+++ b/alembic/versions/ea74eca400ce_sip_to_pjsip_endpoint.py
@@ -982,7 +982,7 @@ def insert_endpoint_config(
 
     query = endpoint_sip_tbl.insert().returning(endpoint_sip_tbl.c.uuid).values(
         label=body['label'],
-        name=generate_unused_name(),
+        name=body.get('name') or generate_unused_name(),
         tenant_uuid=tenant_uuid,
         template=body.get('template', False),
         transport_uuid=body.get('transport_uuid'),


### PR DESCRIPTION
only generate a configuration name if the old configuration did not have one.
This will only happen for templates.

generating a new name at this time would require all devices to be reconfigured