### PR TITLE
sip to pjsip: avoid converting the transport field

### DIFF
--- a/alembic/versions/ea74eca400ce_sip_to_pjsip_endpoint.py
+++ b/alembic/versions/ea74eca400ce_sip_to_pjsip_endpoint.py
@@ -597,7 +597,6 @@ class UserSIP(object):
             'protocol',
             'category',
             'outboundproxy',
-            'transport',
             'remotesecret',
             'directmedia',
             'callcounter',


### PR DESCRIPTION
this field is a relation and should not be added to the endpoint
endpoint_section_options since confgend will add it based on the relation