### PR TITLE
registration migration: generate the missing sections

### DIFF
--- a/alembic/versions/ea74eca400ce_sip_to_pjsip_endpoint.py
+++ b/alembic/versions/ea74eca400ce_sip_to_pjsip_endpoint.py
@@ -1211,15 +1211,18 @@ def sip_to_pjsip(sip_config, transports):
             config['transport_uuid'] = transports.get(kv.value)
 
     if sip_config.registration:
-        register_section_options = sip_config.registration.registration_fields
-        config['register_section_options'] = register_section_options
-        config['outbound_auth_section_options'] = sip_config.registration.auth_fields
+        registration_section_options = sip_config.registration.registration_fields
+        config['registration_section_options'] = registration_section_options
+        config['registration_outbound_auth_section_options'] = sip_config.registration.auth_fields
 
     config.update({
         'aor_section_options': aor_option_accumulator.get_options(),
         'auth_section_options': auth_option_accumulator.get_options(),
         'endpoint_section_options': endpoint_option_accumulator.get_options(),
     })
+
+    if sip_config.category == 'trunk':
+        config['outbound_auth_section_options'] = auth_option_accumulator.get_options()
 
     return config
 


### PR DESCRIPTION
there is a typo in the section name resulting in no registration_section_options
being generated.

I also generated an outbound_auth_section_options on all trunk. This was the
behavior in wazo-confgend when translating from sip to pjsip

The username and password from the register are used to generate the
registration outbound auth section