### PR TITLE
debian: use infos table to validate if tables are initialized

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -40,7 +40,7 @@ case "$1" in
                 export ALEMBIC_DB_URI="postgresql://$db_app_username:$db_app_password@$db_host:$db_port/$db_app_name"
             fi
 
-            if ! $psql_cmd -tA asterisk --quiet -c "SELECT count(*) from userfeatures" > /dev/null; then
+            if ! $psql_cmd -tA asterisk --quiet -c "SELECT count(*) from infos" > /dev/null; then
                 xivo-init-db --init \
                 --pg_db_uri "$pg_db_uri" \
                 --owner "$db_app_username" \


### PR DESCRIPTION
revert: 36f9b41894b23e26dfe77e930f27fb145140ddbe
why: no version before 19.13 will execute this postinst
and userfeatures can be empty even if database is initialized which can cause confusion to the reader