### PR TITLE
switchboard dialaction: don't sort enum values

### DIFF
--- a/alembic/versions/ba7c6bb897b3_add_switchboard_dialaction.py
+++ b/alembic/versions/ba7c6bb897b3_add_switchboard_dialaction.py
@@ -24,7 +24,7 @@ old_categories = (
     'ivr',
     'ivr_choice',
 )
-new_categories = sorted(old_categories + ('switchboard',))
+new_categories = old_categories + ('switchboard',)
 
 new_type = sa.Enum(*new_categories, name='dialaction_category')
 old_type = sa.Enum(*old_categories, name='dialaction_category')


### PR DESCRIPTION
Why:

* enum value order is important in some cases
* compare-db script will flag the difference of order between fresh
install and migrated database