### PR TITLE
Line: Add EndpointSIPOptionsView table creation

### DIFF
--- a/alembic/versions/5ffaec7e8db7_add_endpoint_sip_materialized_view.py
+++ b/alembic/versions/5ffaec7e8db7_add_endpoint_sip_materialized_view.py
@@ -1,0 +1,118 @@
+"""add endpoint_sip materialized view
+
+Revision ID: 5ffaec7e8db7
+Revises: 035e2cb65b6d
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.sql.functions import array_agg, func
+from sqlalchemy.dialects.postgresql.ext import aggregate_order_by
+
+from xivo_dao.helpers.db_views import DDLCreateView, DDLDropView
+
+# revision identifiers, used by Alembic.
+revision = '5ffaec7e8db7'
+down_revision = 'da06cfd76289'
+
+
+def generate_view_selectable():
+    cte = (
+        sa.select(
+            [
+                sa.literal_column('endpoint_sip.uuid').label('uuid'),
+                sa.literal(0).label('level'),
+                sa.literal('0', sa.String).label('path'),
+                sa.literal_column('endpoint_sip.uuid').label('root'),
+            ]
+        )
+        .select_from(sa.table('endpoint_sip'))
+        .cte(recursive=True)
+    )
+
+    endpoints = cte.union_all(
+        sa.select(
+            [
+                sa.literal_column('endpoint_sip_template.parent_uuid').label('uuid'),
+                (cte.c.level + 1).label('level'),
+                (
+                    cte.c.path
+                    + sa.cast(
+                        func.row_number().over(
+                            partition_by='level',
+                            order_by=sa.literal_column(
+                                'endpoint_sip_template.priority'
+                            ),
+                        ),
+                        sa.String,
+                    )
+                ).label('path'),
+                (cte.c.root),
+            ]
+        ).select_from(
+            sa.join(
+                cte,
+                sa.table('endpoint_sip_template'),
+                cte.c.uuid == sa.literal_column('endpoint_sip_template.child_uuid'),
+            )
+        )
+    )
+
+    return (
+        sa.select(
+            [
+                endpoints.c.root,
+                sa.cast(
+                    sa.func.jsonb_object(
+                        array_agg(
+                            aggregate_order_by(
+                                sa.literal_column('endpoint_sip_section_option.key'),
+                                endpoints.c.path.desc(),
+                            )
+                        ),
+                        array_agg(
+                            aggregate_order_by(
+                                sa.literal_column('endpoint_sip_section_option.value'),
+                                endpoints.c.path.desc(),
+                            )
+                        ),
+                    ),
+                    JSONB,
+                ).label('options'),
+            ]
+        )
+        .select_from(
+            sa.join(
+                endpoints,
+                sa.table('endpoint_sip_section'),
+                sa.literal_column('endpoint_sip_section.endpoint_sip_uuid')
+                == endpoints.c.uuid,
+            ).join(
+                sa.table('endpoint_sip_section_option'),
+                sa.literal_column(
+                    'endpoint_sip_section_option.endpoint_sip_section_uuid'
+                )
+                == sa.literal_column('endpoint_sip_section.uuid'),
+            )
+        )
+        .group_by(endpoints.c.root)
+    )
+
+
+def upgrade():
+    op.execute(
+        DDLCreateView('endpoint_sip_options_view', generate_view_selectable(), True)
+    )
+    op.create_index(
+        'endpoint_sip_options_view__idx__root',
+        'endpoint_sip_options_view',
+        ['root'],
+        unique=True,
+    )
+
+
+def downgrade():
+    op.drop_index('endpoint_sip_options_view__idx__root', 'endpoint_sip_mv')
+    op.execute(DDLDropView("endpoint_sip_options_view", True))

--- a/alembic/versions/5ffaec7e8db7_add_endpoint_sip_materialized_view.py
+++ b/alembic/versions/5ffaec7e8db7_add_endpoint_sip_materialized_view.py
@@ -31,7 +31,7 @@ def _compile_create_view(element, compiler, **kw):
     return 'CREATE MATERIALIZED VIEW {} AS {}'.format(name, selectable)
 
 
-# Todo: Replace by SQLAlchemy-Utils when possible
+# TODO: Replace by SQLAlchemy-Utils when possible
 class DropMaterializedView(DDLElement):
     def __init__(self, name, cascade=True):
         self.name = name

--- a/alembic/versions/5ffaec7e8db7_add_endpoint_sip_materialized_view.py
+++ b/alembic/versions/5ffaec7e8db7_add_endpoint_sip_materialized_view.py
@@ -1,7 +1,7 @@
 """add endpoint_sip materialized view
 
 Revision ID: 5ffaec7e8db7
-Revises: 61e3d7c65755
+Revises: 51ebe7954da8
 
 """
 
@@ -15,7 +15,7 @@ from sqlalchemy.sql.functions import array_agg, func
 
 # revision identifiers, used by Alembic.
 revision = '5ffaec7e8db7'
-down_revision = '61e3d7c65755'
+down_revision = '51ebe7954da8'
 
 
 class CreateMaterializedView(DDLElement):

--- a/alembic/versions/5ffaec7e8db7_add_endpoint_sip_materialized_view.py
+++ b/alembic/versions/5ffaec7e8db7_add_endpoint_sip_materialized_view.py
@@ -1,7 +1,7 @@
 """add endpoint_sip materialized view
 
 Revision ID: 5ffaec7e8db7
-Revises: 035e2cb65b6d
+Revises: 61e3d7c65755
 
 """
 
@@ -11,11 +11,11 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.sql.functions import array_agg, func
 from sqlalchemy.dialects.postgresql.ext import aggregate_order_by
 
-from xivo_dao.helpers.db_views import DDLCreateView, DDLDropView
+from xivo_dao.helpers.db_views import CreateView, DropView
 
 # revision identifiers, used by Alembic.
 revision = '5ffaec7e8db7'
-down_revision = 'da06cfd76289'
+down_revision = '61e3d7c65755'
 
 
 def generate_view_selectable():
@@ -103,7 +103,7 @@ def generate_view_selectable():
 
 def upgrade():
     op.execute(
-        DDLCreateView('endpoint_sip_options_view', generate_view_selectable(), True)
+        CreateView('endpoint_sip_options_view', generate_view_selectable(), True)
     )
     op.create_index(
         'endpoint_sip_options_view__idx__root',
@@ -115,4 +115,4 @@ def upgrade():
 
 def downgrade():
     op.drop_index('endpoint_sip_options_view__idx__root', 'endpoint_sip_mv')
-    op.execute(DDLDropView("endpoint_sip_options_view", True))
+    op.execute(DropView("endpoint_sip_options_view", True))


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/xivo-dao/pull/130

Creates the materialized view table in the database to be used
by the DAO

Why:

* Allows a faster way to query inherited options for each SIP endpoint
* Used to allow fast searching/sorting on callerid for linefeatures