### PR TITLE
Add missing foreign keys with ondelete=cascade for some tables

### DIFF
--- a/alembic/versions/70171a0cbf15_add_fk_context_for_contextnumbers.py
+++ b/alembic/versions/70171a0cbf15_add_fk_context_for_contextnumbers.py
@@ -1,0 +1,33 @@
+"""add_fk_context_for_contextnumbers
+
+Revision ID: 70171a0cbf15
+Revises: 85a827ab4711
+
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '70171a0cbf15'
+down_revision = '85a827ab4711'
+
+
+
+def upgrade():
+    op.create_foreign_key(
+        None,
+        "contextnumbers",
+        "context",
+        ["context"],
+        ["name"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        "contextnumbers_context_fkey",
+        "context",
+        type_="foreignkey"
+    )

--- a/alembic/versions/70171a0cbf15_add_fk_context_for_contextnumbers.py
+++ b/alembic/versions/70171a0cbf15_add_fk_context_for_contextnumbers.py
@@ -22,6 +22,7 @@ def upgrade():
         ["context"],
         ["name"],
         ondelete="CASCADE",
+        onupdate="CASCADE",
     )
 
 

--- a/alembic/versions/85a827ab4711_add_fk_context_for_contextmember.py
+++ b/alembic/versions/85a827ab4711_add_fk_context_for_contextmember.py
@@ -1,0 +1,32 @@
+"""add_fk_context_for_contextmember
+
+Revision ID: 85a827ab4711
+Revises: 9869009eb5b3
+
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '85a827ab4711'
+down_revision = '9869009eb5b3'
+
+
+
+def upgrade():
+    op.create_foreign_key(
+        None,
+        "contextmember",
+        "context",
+        ["context"],
+        ["name"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        "contextmember_context_fkey",
+        "context",
+        type_="foreignkey")

--- a/alembic/versions/85a827ab4711_add_fk_context_for_contextmember.py
+++ b/alembic/versions/85a827ab4711_add_fk_context_for_contextmember.py
@@ -22,6 +22,7 @@ def upgrade():
         ["context"],
         ["name"],
         ondelete="CASCADE",
+        onupdate="CASCADE",
     )
 
 

--- a/alembic/versions/9869009eb5b3_add_fk_context_for_voicemail.py
+++ b/alembic/versions/9869009eb5b3_add_fk_context_for_voicemail.py
@@ -1,0 +1,34 @@
+"""add_fk_context_for_voicemail
+
+Revision ID: 9869009eb5b3
+Revises: c9b7c156e02a
+
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '9869009eb5b3'
+down_revision = 'c9b7c156e02a'
+
+
+
+
+def upgrade():
+    op.create_foreign_key(
+        None,
+        "voicemail",
+        "context",
+        ["context"],
+        ["name"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        "voicemail_context_fkey",
+        "context",
+        type_="foreignkey"
+    )

--- a/alembic/versions/9869009eb5b3_add_fk_context_for_voicemail.py
+++ b/alembic/versions/9869009eb5b3_add_fk_context_for_voicemail.py
@@ -23,6 +23,7 @@ def upgrade():
         ["context"],
         ["name"],
         ondelete="CASCADE",
+        onupdate="CASCADE",
     )
 
 

--- a/alembic/versions/c86be8bc0377_add_fk_context_for_contextinclude.py
+++ b/alembic/versions/c86be8bc0377_add_fk_context_for_contextinclude.py
@@ -22,12 +22,27 @@ def upgrade():
         ["context"],
         ["name"],
         ondelete="CASCADE",
+        update="CASCADE",
+    )
+    op.create_foreign_key(
+        None,
+        "contextinclude",
+        "context",
+        ["include"],
+        ["name"],
+        ondelete="CASCADE",
+        update="CASCADE",
     )
 
 
 def downgrade():
     op.drop_constraint(
         "contextinclude_context_fkey",
+        "context",
+        type_="foreignkey"
+    )
+    op.drop_constraint(
+        "contextinclude_include_fkey",
         "context",
         type_="foreignkey"
     )

--- a/alembic/versions/c86be8bc0377_add_fk_context_for_contextinclude.py
+++ b/alembic/versions/c86be8bc0377_add_fk_context_for_contextinclude.py
@@ -22,7 +22,7 @@ def upgrade():
         ["context"],
         ["name"],
         ondelete="CASCADE",
-        update="CASCADE",
+        onupdate="CASCADE",
     )
     op.create_foreign_key(
         None,
@@ -31,7 +31,7 @@ def upgrade():
         ["include"],
         ["name"],
         ondelete="CASCADE",
-        update="CASCADE",
+        onupdate="CASCADE",
     )
 
 

--- a/alembic/versions/c86be8bc0377_add_fk_context_for_contextinclude.py
+++ b/alembic/versions/c86be8bc0377_add_fk_context_for_contextinclude.py
@@ -1,0 +1,33 @@
+"""add_fk_context_for_contextinclude
+
+Revision ID: c86be8bc0377
+Revises: 70171a0cbf15
+
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'c86be8bc0377'
+down_revision = '70171a0cbf15'
+
+
+
+def upgrade():
+    op.create_foreign_key(
+        None,
+        "contextinclude",
+        "context",
+        ["context"],
+        ["name"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade():
+    op.drop_constraint(
+        "contextinclude_context_fkey",
+        "context",
+        type_="foreignkey"
+    )

--- a/alembic/versions/c9b7c156e02a_add_ondelete_cascade_fk_tenant.py
+++ b/alembic/versions/c9b7c156e02a_add_ondelete_cascade_fk_tenant.py
@@ -1,0 +1,36 @@
+"""add_ondelete_cascade_fk_tenant
+
+Revision ID: c9b7c156e02a
+Revises: 8675398b047b
+
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'c9b7c156e02a'
+down_revision = '8675398b047b'
+
+
+def upgrade():
+    op.drop_constraint("context_tenant_uuid_fkey", "context", type_="foreignkey")
+    op.create_foreign_key(
+        None,
+        "context",
+        "tenant",
+        ["tenant_uuid"],
+        ["uuid"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade():
+    op.drop_constraint("context_tenant_uuid_fkey", "context", type_="foreignkey")
+    op.create_foreign_key(
+        None,
+        "context",
+        "tenant",
+        ["tenant_uuid"],
+        ["uuid"]
+    )


### PR DESCRIPTION
Foreign keys with ondelete="CASCADE" added to delete (cascade) some resources related to a tenant.