### PR TITLE
revert bump version (23.11)

### DIFF
--- a/alembic/versions/898154753a9b_revert_bump_version_23_11.py
+++ b/alembic/versions/898154753a9b_revert_bump_version_23_11.py
@@ -1,0 +1,22 @@
+"""revert-bump-version-23-11
+
+Revision ID: 898154753a9b
+Revises: 74818b4464a1
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '898154753a9b'
+down_revision = '74818b4464a1'
+
+
+def upgrade():
+    infos = sa.sql.table('infos', sa.sql.column('wazo_version'))
+    op.execute(infos.update().values(wazo_version='23.10'))
+
+
+def downgrade():
+    pass

--- a/populate/populate.sql
+++ b/populate/populate.sql
@@ -587,6 +587,6 @@ INSERT INTO "provisioning" VALUES(DEFAULT, '', 0, 8667);
 
 /* The UUID "populate-uuid" will be replaced by pg-populate-db */
 /* The version is bumped automatically during the release process */
-INSERT INTO "infos" (uuid, wazo_version, live_reload_enabled, timezone, configured) VALUES ('populate-uuid', '23.11', 'True', 'Europe/Paris', 'False');
+INSERT INTO "infos" (uuid, wazo_version, live_reload_enabled, timezone, configured) VALUES ('populate-uuid', '23.10', 'True', 'Europe/Paris', 'False');
 
 COMMIT;


### PR DESCRIPTION
why: to be able to properly backport cel index fix
the bump version will be readded after this commit