### PR TITLE
[WAZO-3420] Fix provisioning reverse proxy http port

### DIFF
--- a/alembic/versions/7c04166bf667_fix_provisioning_port.py
+++ b/alembic/versions/7c04166bf667_fix_provisioning_port.py
@@ -1,0 +1,28 @@
+"""fix provisioning port
+
+Revision ID: 7c04166bf667
+Revises: 30c3152833be
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '7c04166bf667'
+down_revision = '30c3152833be'
+
+
+def _upgrade_provisioning_port(new_port):
+    prov_tbl = sa.sql.table('provisioning', sa.sql.column('http_port'))
+    query = prov_tbl.update().values(http_port=new_port)
+    op.get_bind().execute(query)
+
+
+def upgrade():
+    _upgrade_provisioning_port(8667)
+
+
+def downgrade():
+    _upgrade_provisioning_port(18667)

--- a/populate/populate.sql
+++ b/populate/populate.sql
@@ -583,7 +583,7 @@ INSERT INTO "mail" VALUES (DEFAULT,'','example.wazo.community','','','');
 INSERT INTO "monitoring" VALUES (DEFAULT,0,NULL,NULL);
 
 
-INSERT INTO "provisioning" VALUES(DEFAULT, '', '', 0, 18667);
+INSERT INTO "provisioning" VALUES(DEFAULT, '', '', 0, 8667);
 
 /* The UUID "populate-uuid" will be replaced by pg-populate-db */
 /* The version is bumped automatically during the release process */


### PR DESCRIPTION
http_port is the value used in phone templates for
the provisioning server. 18667 is not the public port, so
it should not be this value.