### PR TITLE
remove unused tenant from populate.sql

### DIFF
--- a/populate/populate.sql
+++ b/populate/populate.sql
@@ -1,8 +1,5 @@
 BEGIN;
 
-INSERT INTO "tenant" (uuid) VALUES (DEFAULT);
-
-
 INSERT INTO "contexttype" VALUES(DEFAULT, 'internal', 0, 0, '');
 INSERT INTO "contexttype" VALUES(DEFAULT, 'incall', 0, 0, '');
 INSERT INTO "contexttype" VALUES(DEFAULT, 'outcall', 0, 0, '');


### PR DESCRIPTION
why: it was used for MOH only