### PR TITLE
jenkinsfile: build and push containers in separate steps

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,17 +20,33 @@ pipeline {
         ]
       }
     }
-    stage('Docker build') {
+    stage('Docker build base DB') {
       steps {
         sh "docker build --no-cache -t wazoplatform/wazo-base-db:latest -f contribs/docker/wazo-base-db/Dockerfile contribs/docker/wazo-base-db"
+      }
+    }
+    stage('Docker publish base DB') {
+      steps {
+        sh "docker push wazoplatform/wazo-base-db:latest"
+      }
+    }
+    stage('Docker build confd DB') {
+      steps {
         sh "docker build --no-cache -t wazoplatform/wazo-confd-db:latest ."
+      }
+    }
+    stage('Docker publish confd DB') {
+      steps {
+        sh "docker push wazoplatform/wazo-confd-db:latest"
+      }
+    }
+    stage('Docker build confd DB test') {
+      steps {
         sh "docker build --no-cache -t wazoplatform/wazo-confd-db-test:latest -f contribs/docker/wazo-confd-db-test/Dockerfile ."
       }
     }
-    stage('Docker publish') {
+    stage('Docker publish confd DB test') {
       steps {
-        sh "docker push wazoplatform/wazo-base-db:latest"
-        sh "docker push wazoplatform/wazo-confd-db:latest"
         sh "docker push wazoplatform/wazo-confd-db-test:latest"
       }
     }


### PR DESCRIPTION
why: a race condition could happens. Because images are based on the
previous one and if a docker pull is done between two builds (and before
push), then an older image will be pulled and we will build a wrong
image