### PR TITLE
parking: remove global options + all funckeys

### DIFF
--- a/alembic/versions/f64ea9c1a1d3_remove_global_parking_options.py
+++ b/alembic/versions/f64ea9c1a1d3_remove_global_parking_options.py
@@ -1,0 +1,74 @@
+"""remove global parking options
+
+Revision ID: f64ea9c1a1d3
+Revises: 091acfe39b68
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'f64ea9c1a1d3'
+down_revision = '091acfe39b68'
+
+PARKING_OPTIONS = [
+    'comebacktoorigin',
+    'context',
+    'courtesytone',
+    'findslot',
+    'parkedcallhangup',
+    'parkedcallrecording',
+    'parkedcallreparking',
+    'parkedcalltransfers',
+    'parkeddynamic',
+    'parkedmusicclass',
+    'parkedplay',
+    'parkext',
+    'parkinghints',
+    'parkingtime',
+    'parkpos',
+]
+
+features_tbl = sa.sql.table(
+    'features',
+    sa.sql.column('id'),
+    sa.sql.column('filename'),
+    sa.sql.column('category'),
+    sa.sql.column('var_name'),
+)
+func_key_dest_features_tbl = sa.sql.table(
+    'func_key_dest_features',
+    sa.sql.column('features_id'),
+)
+func_key_dest_park_position_tbl = sa.sql.table(
+    'func_key_dest_park_position',
+)
+
+
+def upgrade():
+    parking_features_subquery = sa.sql.select([features_tbl.c.id]).where(
+        sa.and_(
+            features_tbl.c.filename == 'features.conf',
+            features_tbl.c.category == 'general',
+            features_tbl.c.var_name.in_(PARKING_OPTIONS),
+        )
+    )
+    # delete existing funckeys to park to global parking
+    query = func_key_dest_features_tbl.delete().where(
+        func_key_dest_features_tbl.c.features_id.in_(parking_features_subquery)
+    )
+    op.execute(query)
+    # delete all unpark funckeys, as they all point to the global parking
+    query = func_key_dest_park_position_tbl.delete()
+    op.execute(query)
+    # delete features options
+    query = features_tbl.delete().where(
+        features_tbl.c.id.in_(parking_features_subquery)
+    )
+    op.execute(query)
+
+
+def downgrade():
+    pass

--- a/populate/populate.sql
+++ b/populate/populate.sql
@@ -41,21 +41,6 @@ INSERT INTO "feature_extension" (enabled, exten, feature) VALUES (true,'_*51.','
 INSERT INTO "feature_extension" (enabled, exten, feature) VALUES (true,'_*52.','groupmemberleave');
 
 
-INSERT INTO "features" VALUES (DEFAULT,0,0,0,'features.conf','general','parkext','700');
-INSERT INTO "features" VALUES (DEFAULT,0,0,0,'features.conf','general','parkpos','701-750');
-INSERT INTO "features" VALUES (DEFAULT,0,0,0,'features.conf','general','context','parkedcalls');
-INSERT INTO "features" VALUES (DEFAULT,0,0,0,'features.conf','general','parkinghints','no');
-INSERT INTO "features" VALUES (DEFAULT,0,0,0,'features.conf','general','parkingtime','45');
-INSERT INTO "features" VALUES (DEFAULT,0,0,0,'features.conf','general','comebacktoorigin','yes');
-INSERT INTO "features" VALUES (DEFAULT,0,0,1,'features.conf','general','courtesytone',NULL);
-INSERT INTO "features" VALUES (DEFAULT,0,0,0,'features.conf','general','parkedplay','caller');
-INSERT INTO "features" VALUES (DEFAULT,0,0,0,'features.conf','general','parkedcalltransfers','no');
-INSERT INTO "features" VALUES (DEFAULT,0,0,0,'features.conf','general','parkedcallreparking','no');
-INSERT INTO "features" VALUES (DEFAULT,0,0,0,'features.conf','general','parkedcallhangup','no');
-INSERT INTO "features" VALUES (DEFAULT,0,0,0,'features.conf','general','parkedcallrecording','no');
-INSERT INTO "features" VALUES (DEFAULT,0,0,0,'features.conf','general','parkeddynamic','no');
-INSERT INTO "features" VALUES (DEFAULT,0,0,0,'features.conf','general','findslot','next');
-INSERT INTO "features" VALUES (DEFAULT,0,0,0,'features.conf','general','parkedmusicclass','default');
 INSERT INTO "features" VALUES (DEFAULT,0,0,0,'features.conf','general','transferdigittimeout','5');
 INSERT INTO "features" VALUES (DEFAULT,0,0,1,'features.conf','general','xfersound',NULL);
 INSERT INTO "features" VALUES (DEFAULT,0,0,1,'features.conf','general','xferfailsound',NULL);
@@ -140,16 +125,6 @@ VALUES (currval('func_key_id_seq'), 5, (SELECT "uuid" from feature_extension WHE
 INSERT INTO "func_key" (type_id, destination_type_id) VALUES (1, 5);
 INSERT INTO "func_key_dest_service" (func_key_id, destination_type_id, feature_extension_uuid)
 VALUES (currval('func_key_id_seq'), 5, (SELECT "uuid" from feature_extension WHERE "feature" = 'enablednd'));
-
-INSERT INTO "func_key" (type_id, destination_type_id) VALUES (2, 8);
-INSERT INTO "func_key_dest_features" (func_key_id, destination_type_id, features_id)
-VALUES (
-    currval('func_key_id_seq'),
-    8,
-    (SELECT id FROM features WHERE filename = 'features.conf'
-                                AND category = 'general'
-                                AND var_name = 'parkext')
-);
 
 INSERT INTO "func_key" (type_id, destination_type_id) VALUES (3, 8);
 INSERT INTO "func_key_dest_features" (func_key_id, destination_type_id, features_id)


### PR DESCRIPTION
Why:

* Function keys are not migrated and will have to be recreated with a
  parking lot