### PR TITLE
Added migration to clean up incall extensions in limbo

### DIFF
--- a/alembic/versions/b38ce53a1d32_remove_incall_extensions_in_limbo.py
+++ b/alembic/versions/b38ce53a1d32_remove_incall_extensions_in_limbo.py
@@ -1,0 +1,43 @@
+"""remove-extensions-in-limbo
+
+remove extensions from table extensions in *from-extern contexts associated with user 0
+which are incall extensions disassociated from a real destination but not available for new assignments
+Revision ID: b38ce53a1d32
+Revises: 7a7f7c44f943
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'b38ce53a1d32'
+down_revision = '7a7f7c44f943'
+
+extensions_table = sa.table(
+    'extensions',
+    sa.column('id'),
+    sa.column('context'),
+    sa.column('exten'),
+    sa.column('type'),
+    sa.column('typeval'),
+)
+
+
+def upgrade() -> None:
+    query = sa.sql.select([extensions_table.c.id]).where(
+        sa.and_(
+            extensions_table.c.type == 'user',
+            extensions_table.c.typeval == '0',
+            extensions_table.c.context.ilike('%from-extern')
+        )
+    )
+    delete_op = extensions_table.delete().where(
+        extensions_table.c.id.in_(query.alias())
+    )
+    op.get_bind().execute(delete_op)
+
+
+def downgrade() -> None:
+    pass

--- a/alembic/versions/b38ce53a1d32_remove_incall_extensions_in_limbo.py
+++ b/alembic/versions/b38ce53a1d32_remove_incall_extensions_in_limbo.py
@@ -1,6 +1,6 @@
 """remove-extensions-in-limbo
 
-remove extensions from table extensions in *from-extern contexts associated with user 0
+remove extensions from table extensions from incall contexts associated with user 0,
 which are incall extensions disassociated from a real destination but not available for new assignments
 Revision ID: b38ce53a1d32
 Revises: 7a7f7c44f943
@@ -10,10 +10,10 @@ Revises: 7a7f7c44f943
 from alembic import op
 import sqlalchemy as sa
 
-
 # revision identifiers, used by Alembic.
 revision = 'b38ce53a1d32'
 down_revision = '7a7f7c44f943'
+
 
 extensions_table = sa.table(
     'extensions',
@@ -25,16 +25,22 @@ extensions_table = sa.table(
 )
 
 
+context_table = sa.table(
+    'context',
+    sa.column('id'),
+    sa.column('name'),
+    sa.column('contexttype'),
+)
+
+
 def upgrade() -> None:
-    query = sa.sql.select([extensions_table.c.id]).where(
+    delete_op = extensions_table.delete().where(
         sa.and_(
+            extensions_table.c.context == context_table.c.name,
             extensions_table.c.type == 'user',
             extensions_table.c.typeval == '0',
-            extensions_table.c.context.ilike('%from-extern')
+            context_table.c.contexttype == 'incall'
         )
-    )
-    delete_op = extensions_table.delete().where(
-        extensions_table.c.id.in_(query.alias())
     )
     op.get_bind().execute(delete_op)
 


### PR DESCRIPTION
why: those extensions are disassociated but unavailable, caused by user recursive delete improperly deleting incalls

https://wazo-dev.atlassian.net/browse/WP-1205