### PR TITLE
use docker compose without hyphen command

### DIFF
--- a/zuul.d/fetch-logs.yaml
+++ b/zuul.d/fetch-logs.yaml
@@ -1,12 +1,12 @@
 ---
 - hosts: all
   tasks:
-    - name: Extract docker-compose logs
-      shell: "docker-compose logs --no-color --timestamps | gzip -9 > docker-compose.logs.txt.gz"
+    - name: Extract docker compose logs
+      shell: "docker compose logs --no-color --timestamps | gzip -9 > docker-compose.logs.txt.gz"
       args:
         chdir: "{{ zuul.project.src_dir}}/../wazo-tools/compare-db"
 
-    - name: Upload docker-compose logs
+    - name: Upload docker compose logs
       synchronize:
         src: "{{ zuul.project.src_dir}}/../wazo-tools/compare-db/docker-compose.logs.txt.gz"
         dest: "{{ zuul.executor.log_root }}"

--- a/zuul.d/pre-run.yaml
+++ b/zuul.d/pre-run.yaml
@@ -9,18 +9,18 @@
         state: present
 
     - name: Start DB containers
-      command: docker-compose up -d
+      command: docker compose up -d
       args:
         chdir: "{{ zuul.project.src_dir}}/../wazo-tools/compare-db"
 
     - name: Get postgresql-migrated container port
-      command: docker-compose port postgresql-migrated 5432
+      command: docker compose port postgresql-migrated 5432
       register: migrated_host_port
       args:
         chdir: "{{ zuul.project.src_dir}}/../wazo-tools/compare-db"
 
     - name: Get postgresql-installed container port
-      command: docker-compose port postgresql-installed 5432
+      command: docker compose port postgresql-installed 5432
       register: installed_host_port
       args:
         chdir: "{{ zuul.project.src_dir}}/../wazo-tools/compare-db"


### PR DESCRIPTION
why: it's now the recommended way to use docker compose