### PR TITLE
bump version (26.04)

### DIFF
--- a/alembic/versions/517d371081d0_bump_version_26_04.py
+++ b/alembic/versions/517d371081d0_bump_version_26_04.py
@@ -1,0 +1,24 @@
+"""bump_version_26_04
+
+Revision ID: 517d371081d0
+Revises: e01c44b679ed
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '517d371081d0'
+down_revision = 'e01c44b679ed'
+
+
+def upgrade():
+    infos = sa.sql.table('infos', sa.sql.column('wazo_version'))
+    op.execute(infos.update().values(wazo_version='26.04'))
+
+
+def downgrade():
+    pass

--- a/populate/populate.sql
+++ b/populate/populate.sql
@@ -544,6 +544,6 @@ INSERT INTO "provisioning" VALUES(DEFAULT, '', '', 0, 8667);
 
 /* The UUID "populate-uuid" will be replaced by init_db.py */
 /* The version is bumped automatically during the release process */
-INSERT INTO "infos" (uuid, wazo_version, live_reload_enabled, timezone, configured) VALUES ('populate-uuid', '26.03', 'True', 'Europe/Paris', 'False');
+INSERT INTO "infos" (uuid, wazo_version, live_reload_enabled, timezone, configured) VALUES ('populate-uuid', '26.04', 'True', 'Europe/Paris', 'False');
 
 COMMIT;


### PR DESCRIPTION
bump version (26.04)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates the stored `wazo_version` value via migration and seed data; no schema or runtime logic changes.
> 
> **Overview**
> Bumps the system version to `26.04`.
> 
> Adds an Alembic migration (`517d371081d0`) that updates `infos.wazo_version` to `26.04`, and updates the default `populate.sql` seed insert for `infos` from `26.03` to `26.04`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe1942e5769a4bda8c4cacd431b818e5bc5fe773. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->