### PR TITLE
tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-To add new migration script:
+To add new migration script :
 
     alembic -c alembic.ini revision -m 'what you changed'

--- a/zuul.yaml
+++ b/zuul.yaml
@@ -13,10 +13,10 @@
     nodeset: vm-debian-12-m1s
 
 - project:
-    templates:
-      - wazo-tox-py311
-      - wazo-tox-linters-py311
-      - debian-packaging-bookworm
+    # templates:
+    #   - wazo-tox-py311
+    #   - wazo-tox-linters-py311
+    #   - debian-packaging-bookworm
     wazo-check:
       jobs:
         - check-migration


### PR DESCRIPTION
Depends-on: https://github.com/wazo-platform/wazo-tools/pull/77


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI behavior changes by removing default template jobs, which can reduce test coverage and allow regressions to slip through; code/runtime behavior is otherwise unaffected.
> 
> **Overview**
> This PR makes a small doc tweak in `README.md` (spacing/formatting of the migration-script instructions).
> 
> In `zuul.yaml`, it comments out the project `templates` block, effectively disabling the default tox/lint/debian-packaging template jobs while keeping the custom `check-migration` job in `wazo-check`/`wazo-gate` and the existing experimental job.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6951a16a071b75119ccc1e9ccf4220f7d14ef02. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->