### PR TITLE
[TASK-138] new table: voicemail_transcription_config

### DIFF
--- a/alembic/versions/0433093321f1_add_voicemail_transcription_config.py
+++ b/alembic/versions/0433093321f1_add_voicemail_transcription_config.py
@@ -1,0 +1,27 @@
+"""add voicemail transcription config
+
+Revision ID: 0433093321f1
+Revises: 517d371081d0
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.sql import text
+
+# revision identifiers, used by Alembic.
+revision = '0433093321f1'
+down_revision = '517d371081d0'
+
+COLUMN = 'voicemail_transcription_enabled'
+
+
+def upgrade():
+    op.add_column(
+        'tenant',
+        sa.Column(COLUMN, sa.Boolean(), nullable=False, server_default=text('false')),
+    )
+
+
+def downgrade():
+    op.drop_column('tenant', COLUMN)


### PR DESCRIPTION
Depends-on: https://github.com/wazo-platform/xivo-dao/pull/341

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, single additive schema migration adding a boolean column with a safe default; primary risk is rollout issues if any code assumes the column exists before migration.
> 
> **Overview**
> Adds an Alembic migration that introduces `tenant.voicemail_transcription_enabled` (non-null `Boolean` with server default `false`) to gate voicemail transcription per tenant, with a downgrade that drops the column.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6af6b1809fbd24e2193f03ad70074ed3528d01ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->