### PR TITLE
bump version (26.05)

### DIFF
--- a/alembic/versions/f3bc803db64e_bump_version_26_05.py
+++ b/alembic/versions/f3bc803db64e_bump_version_26_05.py
@@ -1,0 +1,24 @@
+"""bump_version_26_05
+
+Revision ID: f3bc803db64e
+Revises: 0433093321f1
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'f3bc803db64e'
+down_revision = '0433093321f1'
+
+
+def upgrade():
+    infos = sa.sql.table('infos', sa.sql.column('wazo_version'))
+    op.execute(infos.update().values(wazo_version='26.05'))
+
+
+def downgrade():
+    pass

--- a/populate/populate.sql
+++ b/populate/populate.sql
@@ -544,6 +544,6 @@ INSERT INTO "provisioning" VALUES(DEFAULT, '', '', 0, 8667);
 
 /* The UUID "populate-uuid" will be replaced by init_db.py */
 /* The version is bumped automatically during the release process */
-INSERT INTO "infos" (uuid, wazo_version, live_reload_enabled, timezone, configured) VALUES ('populate-uuid', '26.04', 'True', 'Europe/Paris', 'False');
+INSERT INTO "infos" (uuid, wazo_version, live_reload_enabled, timezone, configured) VALUES ('populate-uuid', '26.05', 'True', 'Europe/Paris', 'False');
 
 COMMIT;


### PR DESCRIPTION
bump version (26.05)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates a stored version string via an Alembic migration and the default DB populate script, with no schema or behavioral changes.
> 
> **Overview**
> Bumps the recorded `wazo_version` to `26.05`.
> 
> Adds an Alembic migration that updates the `infos.wazo_version` value for existing databases, and updates `populate.sql` so newly initialized databases start with `26.05`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26b1b0010626efb28b9070c86ad5415e6b7f0920. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->