### PR TITLE
[ITEM-205] Remove call listening feature + function key

### DIFF
--- a/alembic/versions/6e41fc32adcb_remove_calllistening_feature.py
+++ b/alembic/versions/6e41fc32adcb_remove_calllistening_feature.py
@@ -41,17 +41,41 @@ func_key_table = sa.sql.table(
 def upgrade():
     conn = op.get_bind()
 
+    calllistening_uuids = (
+        sa.select([feature_extension_table.c.uuid])
+        .where(feature_extension_table.c.feature == FEATURE)
+    )
+
+    # Collect func_key IDs before deleting the dest_service rows
+    func_key_ids = [
+        row[0] for row in conn.execute(
+            sa.select([func_key_dest_service_table.c.func_key_id])
+            .where(
+                func_key_dest_service_table.c.feature_extension_uuid.in_(
+                    calllistening_uuids
+                )
+            )
+        )
+    ]
+
     # Remove func_key_dest_service entries referencing calllistening
     conn.execute(
         func_key_dest_service_table
         .delete()
         .where(
             func_key_dest_service_table.c.feature_extension_uuid.in_(
-                sa.select([feature_extension_table.c.uuid])
-                .where(feature_extension_table.c.feature == FEATURE)
+                calllistening_uuids
             )
         )
     )
+
+    # Remove func_key entries that pointed to calllistening destinations
+    if func_key_ids:
+        conn.execute(
+            func_key_table
+            .delete()
+            .where(func_key_table.c.id.in_(func_key_ids))
+        )
 
     # Remove the feature extension itself
     conn.execute(

--- a/alembic/versions/6e41fc32adcb_remove_calllistening_feature.py
+++ b/alembic/versions/6e41fc32adcb_remove_calllistening_feature.py
@@ -1,0 +1,91 @@
+"""remove calllistening feature
+
+Revision ID: 6e41fc32adcb
+Revises: f3bc803db64e
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '6e41fc32adcb'
+down_revision = 'f3bc803db64e'
+
+FEATURE = 'calllistening'
+EXTEN = '*34'
+
+feature_extension_table = sa.sql.table(
+    'feature_extension',
+    sa.sql.column('uuid'),
+    sa.sql.column('enabled'),
+    sa.sql.column('exten'),
+    sa.sql.column('feature'),
+)
+
+func_key_dest_service_table = sa.sql.table(
+    'func_key_dest_service',
+    sa.sql.column('func_key_id'),
+    sa.sql.column('destination_type_id'),
+    sa.sql.column('feature_extension_uuid'),
+)
+
+func_key_table = sa.sql.table(
+    'func_key',
+    sa.sql.column('id'),
+    sa.sql.column('type_id'),
+    sa.sql.column('destination_type_id'),
+)
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    # Remove func_key_dest_service entries referencing calllistening
+    conn.execute(
+        func_key_dest_service_table
+        .delete()
+        .where(
+            func_key_dest_service_table.c.feature_extension_uuid.in_(
+                sa.select([feature_extension_table.c.uuid])
+                .where(feature_extension_table.c.feature == FEATURE)
+            )
+        )
+    )
+
+    # Remove the feature extension itself
+    conn.execute(
+        feature_extension_table
+        .delete()
+        .where(feature_extension_table.c.feature == FEATURE)
+    )
+
+
+def downgrade():
+    conn = op.get_bind()
+
+    conn.execute(
+        feature_extension_table
+        .insert()
+        .values(enabled=False, exten=EXTEN, feature=FEATURE)
+    )
+
+    conn.execute(
+        func_key_table
+        .insert()
+        .values(type_id=1, destination_type_id=5)
+    )
+
+    conn.execute(
+        func_key_dest_service_table
+        .insert()
+        .values(
+            func_key_id=sa.func.currval('func_key_id_seq'),
+            destination_type_id=5,
+            feature_extension_uuid=(
+                sa.select([feature_extension_table.c.uuid])
+                .where(feature_extension_table.c.feature == FEATURE)
+                .scalar_subquery()
+            ),
+        )
+    )

--- a/alembic/versions/6e41fc32adcb_remove_calllistening_feature.py
+++ b/alembic/versions/6e41fc32adcb_remove_calllistening_feature.py
@@ -30,6 +30,12 @@ func_key_dest_service_table = sa.sql.table(
     sa.sql.column('feature_extension_uuid'),
 )
 
+func_key_mapping_table = sa.sql.table(
+    'func_key_mapping',
+    sa.sql.column('func_key_id'),
+    sa.sql.column('template_id'),
+)
+
 func_key_table = sa.sql.table(
     'func_key',
     sa.sql.column('id'),
@@ -69,8 +75,15 @@ def upgrade():
         )
     )
 
-    # Remove func_key entries that pointed to calllistening destinations
     if func_key_ids:
+        # Remove func_key_mapping entries before deleting func_keys (FK constraint)
+        conn.execute(
+            func_key_mapping_table
+            .delete()
+            .where(func_key_mapping_table.c.func_key_id.in_(func_key_ids))
+        )
+
+        # Remove func_key entries that pointed to calllistening destinations
         conn.execute(
             func_key_table
             .delete()

--- a/populate/populate.sql
+++ b/populate/populate.sql
@@ -11,7 +11,6 @@ INSERT INTO "feature_extension" (enabled, exten, feature) VALUES (true,'_*31.','
 INSERT INTO "feature_extension" (enabled, exten, feature) VALUES (true,'_*32.','agentstaticlogoff');
 INSERT INTO "feature_extension" (enabled, exten, feature) VALUES (true,'_*30.','agentstaticlogtoggle');
 INSERT INTO "feature_extension" (enabled, exten, feature) VALUES (true,'_*37.','bsfilter');
-INSERT INTO "feature_extension" (enabled, exten, feature) VALUES (false,'*34','calllistening');
 INSERT INTO "feature_extension" (enabled, exten, feature) VALUES (false,'*26','callrecord');
 INSERT INTO "feature_extension" (enabled, exten, feature) VALUES (true,'*36','directoryaccess');
 INSERT INTO "feature_extension" (enabled, exten, feature) VALUES (true,'*25','enablednd');
@@ -98,10 +97,6 @@ VALUES (currval('func_key_id_seq'), 5, (SELECT "uuid" from feature_extension WHE
 INSERT INTO "func_key" (type_id, destination_type_id) VALUES (1, 5);
 INSERT INTO "func_key_dest_service" (func_key_id, destination_type_id, feature_extension_uuid)
 VALUES (currval('func_key_id_seq'), 5, (SELECT "uuid" from feature_extension WHERE "feature" = 'recsnd'));
-
-INSERT INTO "func_key" (type_id, destination_type_id) VALUES (1, 5);
-INSERT INTO "func_key_dest_service" (func_key_id, destination_type_id, feature_extension_uuid)
-VALUES (currval('func_key_id_seq'), 5, (SELECT "uuid" from feature_extension WHERE "feature" = 'calllistening'));
 
 INSERT INTO "func_key" (type_id, destination_type_id) VALUES (1, 5);
 INSERT INTO "func_key_dest_service" (func_key_id, destination_type_id, feature_extension_uuid)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Destructive database migration deletes `feature_extension` and related `func_key*` rows, which could impact existing deployments if anything still references `calllistening`. Downgrade recreates only a minimal default record set, so rollback may not fully restore prior custom mappings.
> 
> **Overview**
> Removes the `calllistening` feature (`*34`) from the database by adding an Alembic migration that deletes the `feature_extension` row and cleans up related `func_key_dest_service`, `func_key_mapping`, and `func_key` entries that referenced it.
> 
> Updates `populate.sql` to stop seeding `calllistening` in both `feature_extension` and the default service `func_key` entries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b86f965e407c411f3411f51fd3b976f61f1445fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->