### PR TITLE
[ITEM-229] pjsip: set taskpool_max_size with value 100

### DIFF
--- a/alembic/versions/38cc382d720f_set_taskpool_max_size.py
+++ b/alembic/versions/38cc382d720f_set_taskpool_max_size.py
@@ -1,0 +1,72 @@
+"""set taskpool_max_size
+
+Revision ID: 38cc382d720f
+Revises: f3bc803db64e
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '38cc382d720f'
+down_revision = 'f3bc803db64e'
+
+
+asterisk_file = sa.sql.table(
+    'asterisk_file',
+    sa.sql.column('id'),
+    sa.sql.column('name'),
+)
+asterisk_file_section = sa.sql.table(
+    'asterisk_file_section',
+    sa.sql.column('id'),
+    sa.sql.column('name'),
+    sa.sql.column('asterisk_file_id'),
+)
+asterisk_file_variable = sa.sql.table(
+    'asterisk_file_variable',
+    sa.sql.column('id'),
+    sa.sql.column('key'),
+    sa.sql.column('value'),
+    sa.sql.column('asterisk_file_section_id'),
+)
+
+PJSIP_SYSTEM_SECTION_ID = (
+    sa.select(asterisk_file_section.c.id)
+    .where(asterisk_file_section.c.name == 'system')
+    .where(
+        asterisk_file_section.c.asterisk_file_id
+        == sa.select(asterisk_file.c.id)
+        .where(asterisk_file.c.name == 'pjsip.conf')
+        .scalar_subquery()
+    )
+    .scalar_subquery()
+)
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    exists = conn.execute(
+        sa.select(asterisk_file_variable.c.id).where(
+            asterisk_file_variable.c.key == 'taskpool_max_size',
+            asterisk_file_variable.c.asterisk_file_section_id == PJSIP_SYSTEM_SECTION_ID,
+        )
+    ).fetchone()
+    if exists:
+        return
+
+    conn.execute(
+        asterisk_file_variable.insert().values(
+            key='taskpool_max_size',
+            value='100',
+            asterisk_file_section_id=PJSIP_SYSTEM_SECTION_ID,
+        )
+    )
+
+
+def downgrade():
+    pass

--- a/populate/populate.sql
+++ b/populate/populate.sql
@@ -267,6 +267,8 @@ INSERT INTO "asterisk_file_section" (name, priority, asterisk_file_id) VALUES
 INSERT INTO "asterisk_file_variable" (key, value, asterisk_file_section_id) VALUES
   ('user_agent', 'Wazo PBX', (SELECT id FROM asterisk_file_section WHERE name = 'global' AND asterisk_file_id = (SELECT id FROM asterisk_file WHERE name = 'pjsip.conf'))),
   ('endpoint_identifier_order', 'auth_username,username,ip', (SELECT id FROM asterisk_file_section WHERE name = 'global' AND asterisk_file_id = (SELECT id FROM asterisk_file WHERE name = 'pjsip.conf')));
+INSERT INTO "asterisk_file_variable" (key, value, asterisk_file_section_id) VALUES
+  ('taskpool_max_size', 100, (SELECT id FROM asterisk_file_section WHERE name = 'system' AND asterisk_file_id = (SELECT id FROM asterisk_file WHERE name = 'pjsip.conf')));
 
 INSERT INTO "staticvoicemail" VALUES (DEFAULT,0,0,0,'voicemail.conf','general','maxmsg',100);
 INSERT INTO "staticvoicemail" VALUES (DEFAULT,0,0,0,'voicemail.conf','general','silencethreshold',256);


### PR DESCRIPTION
Why: default of 50 is too low.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default PJSIP system configuration persisted in the database, which can affect Asterisk runtime behavior and capacity. Migration is not reversible (`downgrade()` is a no-op), so rollback requires manual cleanup.
> 
> **Overview**
> Sets the PJSIP `system` setting `taskpool_max_size` to `100` in the database-backed `pjsip.conf` config.
> 
> Adds an Alembic migration that inserts `taskpool_max_size=100` for the `system` section if it doesn’t already exist, and updates `populate.sql` so new installs are seeded with the same value.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 372de4754e6c98475806ddcf8aa278defe264abf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->