### PR TITLE
bump version (26.06)

### DIFF
--- a/alembic/versions/8863a45bcbd0_bump_version_26_06.py
+++ b/alembic/versions/8863a45bcbd0_bump_version_26_06.py
@@ -1,0 +1,24 @@
+"""bump_version_26_06
+
+Revision ID: 8863a45bcbd0
+Revises: 6e41fc32adcb
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '8863a45bcbd0'
+down_revision = '6e41fc32adcb'
+
+
+def upgrade():
+    infos = sa.sql.table('infos', sa.sql.column('wazo_version'))
+    op.execute(infos.update().values(wazo_version='26.06'))
+
+
+def downgrade():
+    pass

--- a/populate/populate.sql
+++ b/populate/populate.sql
@@ -539,6 +539,6 @@ INSERT INTO "provisioning" VALUES(DEFAULT, '', '', 0, 8667);
 
 /* The UUID "populate-uuid" will be replaced by init_db.py */
 /* The version is bumped automatically during the release process */
-INSERT INTO "infos" (uuid, wazo_version, live_reload_enabled, timezone, configured) VALUES ('populate-uuid', '26.05', 'True', 'Europe/Paris', 'False');
+INSERT INTO "infos" (uuid, wazo_version, live_reload_enabled, timezone, configured) VALUES ('populate-uuid', '26.06', 'True', 'Europe/Paris', 'False');
 
 COMMIT;


### PR DESCRIPTION
bump version (26.06)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: release version bump only, updating the `infos.wazo_version` value via migration and initial DB seed data.
> 
> **Overview**
> Updates the stored Wazo release version to `26.06`.
> 
> Adds an Alembic migration (`8863a45bcbd0_bump_version_26_06.py`) that updates `infos.wazo_version`, and bumps the seeded `wazo_version` in `populate.sql` from `26.05` to `26.06` for new database initializations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15751abea54909bce6f949ff107e6f96d71e7c2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->