### PR TITLE
Add mobile_fallback_enabled to userfeatures

### DIFF
--- a/alembic/versions/0dd9e46ce2bc_add_mobile_fallback_enabled_to_.py
+++ b/alembic/versions/0dd9e46ce2bc_add_mobile_fallback_enabled_to_.py
@@ -1,0 +1,32 @@
+"""add_mobile_fallback_enabled_to_userfeatures
+
+Revision ID: 0dd9e46ce2bc
+Revises: 8863a45bcbd0
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+from sqlalchemy.sql import text
+
+
+# revision identifiers, used by Alembic.
+revision = '0dd9e46ce2bc'
+down_revision = '8863a45bcbd0'
+
+
+def upgrade():
+    op.add_column(
+        'userfeatures',
+        sa.Column(
+            'mobile_fallback_enabled',
+            sa.Boolean,
+            nullable=False,
+            server_default=text('false'),
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column('userfeatures', 'mobile_fallback_enabled')


### PR DESCRIPTION
Why: GSM fallback feature (TASK-242) needs a per-user flag to opt into
receiving calls on their GSM number when their mobile app doesn't
register in time for an incoming push call.

Depends-On: https://github.com/wazo-platform/xivo-dao/pull/346

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk schema-only change that adds a non-null boolean with a safe default; main risk is unexpected assumptions in code that maps `userfeatures` rows.
> 
> **Overview**
> Adds an Alembic migration that introduces `userfeatures.mobile_fallback_enabled` as a **non-null** boolean with a server default of `false`, and provides a downgrade to drop the column.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e23a3f09bf1a7cdd346583ffbde944eea1f13822. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->