### PR TITLE
[ITEM-295] Add queues to agent stats

### DIFF
--- a/alembic/versions/091ab2e3ff4d_add_stat_queue_id_to_stat_agent_periodic.py
+++ b/alembic/versions/091ab2e3ff4d_add_stat_queue_id_to_stat_agent_periodic.py
@@ -1,7 +1,7 @@
 """add stat_queue_id to stat_agent_periodic
 
 Revision ID: 091ab2e3ff4d
-Revises: 0dd9e46ce2bc
+Revises: cb49d48129fd
 
 """
 
@@ -12,7 +12,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '091ab2e3ff4d'
-down_revision = '0dd9e46ce2bc'
+down_revision = 'cb49d48129fd'
 
 
 def upgrade():

--- a/alembic/versions/091ab2e3ff4d_add_stat_queue_id_to_stat_agent_periodic.py
+++ b/alembic/versions/091ab2e3ff4d_add_stat_queue_id_to_stat_agent_periodic.py
@@ -1,0 +1,32 @@
+"""add stat_queue_id to stat_agent_periodic
+
+Revision ID: 091ab2e3ff4d
+Revises: 8863a45bcbd0
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '091ab2e3ff4d'
+down_revision = '8863a45bcbd0'
+
+
+def upgrade():
+    op.add_column(
+        'stat_agent_periodic',
+        sa.Column('stat_queue_id', sa.Integer, sa.ForeignKey('stat_queue.id'), nullable=True),
+    )
+    op.create_index(
+        'stat_agent_periodic__idx__stat_queue_id',
+        'stat_agent_periodic',
+        ['stat_queue_id'],
+    )
+
+
+def downgrade():
+    op.drop_index('stat_agent_periodic__idx__stat_queue_id', 'stat_agent_periodic')
+    op.drop_column('stat_agent_periodic', 'stat_queue_id')

--- a/alembic/versions/091ab2e3ff4d_add_stat_queue_id_to_stat_agent_periodic.py
+++ b/alembic/versions/091ab2e3ff4d_add_stat_queue_id_to_stat_agent_periodic.py
@@ -1,7 +1,7 @@
 """add stat_queue_id to stat_agent_periodic
 
 Revision ID: 091ab2e3ff4d
-Revises: 8863a45bcbd0
+Revises: 0dd9e46ce2bc
 
 """
 
@@ -12,7 +12,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '091ab2e3ff4d'
-down_revision = '8863a45bcbd0'
+down_revision = '0dd9e46ce2bc'
 
 
 def upgrade():


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/xivo-dao/pull/345


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Schema migration on stats tables affects reporting and any code that reads/writes `stat_agent_periodic`; nullable FK limits breakage but deploy order with xivo-dao must be coordinated.
> 
> **Overview**
> Adds an Alembic migration that links **periodic agent statistics** to **queues** by introducing a nullable `stat_queue_id` on `stat_agent_periodic`, with a foreign key to `stat_queue.id` and an index on that column for query performance. The downgrade removes the index and column. This supports **[ITEM-295]** queue-scoped agent stats and aligns with the related **xivo-dao** change noted in the PR description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab531bb66de724f3d6ab4f988993683468fd8da1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->