### PR TITLE
bump version (26.07)

### DIFF
--- a/alembic/versions/cb49d48129fd_bump_version_26_07.py
+++ b/alembic/versions/cb49d48129fd_bump_version_26_07.py
@@ -1,0 +1,24 @@
+"""bump_version_26_07
+
+Revision ID: cb49d48129fd
+Revises: 0dd9e46ce2bc
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'cb49d48129fd'
+down_revision = '0dd9e46ce2bc'
+
+
+def upgrade():
+    infos = sa.sql.table('infos', sa.sql.column('wazo_version'))
+    op.execute(infos.update().values(wazo_version='26.07'))
+
+
+def downgrade():
+    pass

--- a/populate/populate.sql
+++ b/populate/populate.sql
@@ -539,6 +539,6 @@ INSERT INTO "provisioning" VALUES(DEFAULT, '', '', 0, 8667);
 
 /* The UUID "populate-uuid" will be replaced by init_db.py */
 /* The version is bumped automatically during the release process */
-INSERT INTO "infos" (uuid, wazo_version, live_reload_enabled, timezone, configured) VALUES ('populate-uuid', '26.06', 'True', 'Europe/Paris', 'False');
+INSERT INTO "infos" (uuid, wazo_version, live_reload_enabled, timezone, configured) VALUES ('populate-uuid', '26.07', 'True', 'Europe/Paris', 'False');
 
 COMMIT;


### PR DESCRIPTION
bump version (26.07)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a simple Alembic migration and updates seed data to reflect the new release version, with no functional or schema changes beyond the `infos.wazo_version` value.
> 
> **Overview**
> Bumps the stored Wazo release version to `26.07`.
> 
> Adds an Alembic migration that updates `infos.wazo_version` to `26.07`, and updates `populate.sql` so newly initialized databases are seeded with `wazo_version='26.07'`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6eec3e2528bd6565d617d1a24d0ee3024e676357. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->