### PR TITLE
rtp: set stunaddr_reresolve_ttl_0 to yes

### DIFF
--- a/alembic/versions/d55959673959_enable_stunaddr_reresolve_ttl_0.py
+++ b/alembic/versions/d55959673959_enable_stunaddr_reresolve_ttl_0.py
@@ -1,0 +1,98 @@
+"""enable stunaddr_reresolve_ttl_0 in rtp.conf
+
+Revision ID: d55959673959
+Revises: 091ab2e3ff4d
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'd55959673959'
+down_revision = '091ab2e3ff4d'
+
+KEY = 'stunaddr_reresolve_ttl_0'
+VALUE = 'yes'
+
+asterisk_file_table = sa.sql.table(
+    'asterisk_file',
+    sa.sql.column('id'),
+    sa.sql.column('name'),
+)
+
+asterisk_file_section_table = sa.sql.table(
+    'asterisk_file_section',
+    sa.sql.column('id'),
+    sa.sql.column('name'),
+    sa.sql.column('asterisk_file_id'),
+)
+
+asterisk_file_variable_table = sa.sql.table(
+    'asterisk_file_variable',
+    sa.sql.column('id'),
+    sa.sql.column('key'),
+    sa.sql.column('value'),
+    sa.sql.column('asterisk_file_section_id'),
+)
+
+
+def _rtp_general_section_id(conn):
+    file_id = conn.execute(
+        sa.select([asterisk_file_table.c.id])
+        .where(asterisk_file_table.c.name == 'rtp.conf')
+    ).scalar()
+    if file_id is None:
+        return None
+    return conn.execute(
+        sa.select([asterisk_file_section_table.c.id])
+        .where(
+            sa.and_(
+                asterisk_file_section_table.c.name == 'general',
+                asterisk_file_section_table.c.asterisk_file_id == file_id,
+            )
+        )
+    ).scalar()
+
+
+def upgrade():
+    conn = op.get_bind()
+    section_id = _rtp_general_section_id(conn)
+    if section_id is None:
+        return
+
+    already_set = conn.execute(
+        sa.select([asterisk_file_variable_table.c.id])
+        .where(
+            sa.and_(
+                asterisk_file_variable_table.c.key == KEY,
+                asterisk_file_variable_table.c.asterisk_file_section_id == section_id,
+            )
+        )
+    ).scalar()
+    if already_set is not None:
+        return
+
+    conn.execute(
+        asterisk_file_variable_table.insert().values(
+            key=KEY,
+            value=VALUE,
+            asterisk_file_section_id=section_id,
+        )
+    )
+
+
+def downgrade():
+    conn = op.get_bind()
+    section_id = _rtp_general_section_id(conn)
+    if section_id is None:
+        return
+
+    conn.execute(
+        asterisk_file_variable_table.delete().where(
+            sa.and_(
+                asterisk_file_variable_table.c.key == KEY,
+                asterisk_file_variable_table.c.asterisk_file_section_id == section_id,
+            )
+        )
+    )

--- a/populate/populate.sql
+++ b/populate/populate.sql
@@ -248,6 +248,9 @@ INSERT INTO "asterisk_file_variable" (key, value, asterisk_file_section_id) VALU
 INSERT INTO "asterisk_file_variable" (key, value, asterisk_file_section_id) VALUES ('rtpend', '20000', (SELECT id FROM asterisk_file_section
                                                                                                           WHERE name = 'general'
                                                                                                           AND asterisk_file_id = (SELECT id FROM asterisk_file WHERE name = 'rtp.conf')));
+INSERT INTO "asterisk_file_variable" (key, value, asterisk_file_section_id) VALUES ('stunaddr_reresolve_ttl_0', 'yes', (SELECT id FROM asterisk_file_section
+                                                                                                          WHERE name = 'general'
+                                                                                                          AND asterisk_file_id = (SELECT id FROM asterisk_file WHERE name = 'rtp.conf')));
 INSERT INTO "asterisk_file_section" (name, priority, asterisk_file_id) VALUES ('ice_host_candidates', NULL, (SELECT id FROM asterisk_file WHERE name = 'rtp.conf'));
 INSERT INTO "asterisk_file" (name) VALUES ('hep.conf');
 INSERT INTO "asterisk_file_section" (name, priority, asterisk_file_id) VALUES ('general', 0, (SELECT id FROM asterisk_file WHERE name = 'hep.conf'));


### PR DESCRIPTION
Why: this enables natively a patch that was removed
Upstream fix: https://github.com/asterisk/asterisk/pull/1918

Previously, using the Wazo patch did not need configuration because it was always enabled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default RTP/STUN behavior for all upgraded and fresh systems; impact is limited to media/NAT handling rather than auth or data, but misconfiguration could affect WebRTC or NAT call setup.
> 
> **Overview**
> Turns on Asterisk **`stunaddr_reresolve_ttl_0=yes`** in the **`rtp.conf`** `[general]` section so STUN address re-resolution when TTL is zero is enabled by default, replacing behavior that used to come from a removed patch.
> 
> **Existing deployments** get the setting via a new Alembic migration that inserts into `asterisk_file_variable` (no-op if `rtp.conf` / `[general]` is missing or the key is already present; downgrade deletes the row). **New installs** pick up the same default from an added row in `populate.sql`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5c18489aa715ea0dd73a76a830741d511727144. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->