### PR TITLE
bump version (26.08)

### DIFF
--- a/alembic/versions/1e0ff683a94e_bump_version_26_08.py
+++ b/alembic/versions/1e0ff683a94e_bump_version_26_08.py
@@ -1,0 +1,24 @@
+"""bump_version_26_08
+
+Revision ID: 1e0ff683a94e
+Revises: d55959673959
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '1e0ff683a94e'
+down_revision = 'd55959673959'
+
+
+def upgrade():
+    infos = sa.sql.table('infos', sa.sql.column('wazo_version'))
+    op.execute(infos.update().values(wazo_version='26.08'))
+
+
+def downgrade():
+    pass

--- a/populate/populate.sql
+++ b/populate/populate.sql
@@ -542,6 +542,6 @@ INSERT INTO "provisioning" VALUES(DEFAULT, '', '', 0, 8667);
 
 /* The UUID "populate-uuid" will be replaced by init_db.py */
 /* The version is bumped automatically during the release process */
-INSERT INTO "infos" (uuid, wazo_version, live_reload_enabled, timezone, configured) VALUES ('populate-uuid', '26.07', 'True', 'Europe/Paris', 'False');
+INSERT INTO "infos" (uuid, wazo_version, live_reload_enabled, timezone, configured) VALUES ('populate-uuid', '26.08', 'True', 'Europe/Paris', 'False');
 
 COMMIT;


### PR DESCRIPTION
bump version (26.08)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routine version metadata only; no application logic or schema changes beyond updating `infos.wazo_version`.
> 
> **Overview**
> Bumps the stored Wazo release version from **26.07** to **26.08** for upgrades and new database seeds.
> 
> An Alembic migration (`1e0ff683a94e`) runs an `UPDATE` on `infos.wazo_version` during upgrade; `downgrade()` is a no-op. **`populate/populate.sql`** sets the default `wazo_version` in the `infos` insert to `26.08` so fresh installs match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50747b431f427756637c4780fc3d67adae68adbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->